### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso17442"
 rust-version = "1.87.0"
-version = "0.2.0"
+version = "0.3.0"
 
 [profile.release]
 lto = true

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/jcape/iso17442/compare/v0.2.0...v0.3.0) - 2025-09-09
+
+### Added
+
+- [**breaking**] implement deref for owned lei, add lou, id accessors
+- inline one-liners
+- [**breaking**] improve errors, add custom string ser/de.
+- serde and display implementations
+
+### Fixed
+
+- add more serde visitor types.
+
+### Other
+
+- added examples to readme, more codecov
+- *(ci)* build and test under all featuresets
+
 ## [0.2.0](https://github.com/jcape/iso17442/compare/v0.1.0...v0.2.0) - 2025-06-16
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `iso17442-types`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `iso17442-types` breaking changes

```text
--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant Error::InvalidLength in /tmp/.tmpAMQejq/iso17442/types/src/lib.rs:115

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Lei::as_bytes, previously in file /tmp/.tmpR1FXvH/iso17442-types/src/lib.rs:199
  Lei::as_str, previously in file /tmp/.tmpR1FXvH/iso17442-types/src/lib.rs:205
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/jcape/iso17442/compare/v0.2.0...v0.3.0) - 2025-09-09

### Added

- [**breaking**] implement deref for owned lei, add lou, id accessors
- inline one-liners
- [**breaking**] improve errors, add custom string ser/de.
- serde and display implementations

### Fixed

- add more serde visitor types.

### Other

- added examples to readme, more codecov
- *(ci)* build and test under all featuresets
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).