### PR TITLE
chore: release v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso17442"
 rust-version = "1.87.0"
-version = "0.3.0"
+version = "0.3.1"
 
 [profile.release]
 lto = true

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/jcape/iso17442/compare/v0.3.0...v0.3.1) - 2025-12-21
+
+### Fixed
+
+- missing panic doc
+- stronger clippy restrictions
+
 ## [0.3.0](https://github.com/jcape/iso17442/compare/v0.2.0...v0.3.0) - 2025-09-09
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `iso17442-types`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/jcape/iso17442/compare/v0.3.0...v0.3.1) - 2025-12-21

### Fixed

- missing panic doc
- stronger clippy restrictions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).