### PR TITLE
chore: release v0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso17442"
 rust-version = "1.87.0"
-version = "0.3.1"
+version = "0.3.2"
 
 [profile.release]
 lto = true

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/jcape/iso17442/compare/v0.3.1...v0.3.2) - 2026-01-02
+
+### Other
+
+- make tests depend on alloc, not std.
+- fix badges
+
 ## [0.3.1](https://github.com/jcape/iso17442/compare/v0.3.0...v0.3.1) - 2025-12-21
 
 ### Fixed

--- a/types/README.md
+++ b/types/README.md
@@ -37,8 +37,8 @@ Both of these types are fully usable in the `const` context, making them suitabl
 [license-image]: https://img.shields.io/github/license/jcape/iso17442?style=for-the-badge
 [license-link]: ../LICENSE
 [crate-image]: https://img.shields.io/crates/v/iso17442-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso17442-types/0.3.0
+[crate-link]: https://crates.io/crates/iso17442-types/0.3.2
 [docs-image]: https://img.shields.io/docsrs/iso17442-types?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso17442-types/0.3.0
-[deps-image]: https://deps.rs/crate/iso17442-types/0.3.0/status.svg?style=for-the-badge
-[deps-link]: https://deps.rs/crate/iso17442-types/0.3.0
+[docs-link]: https://docs.rs/crate/iso17442-types/0.3.2
+[deps-image]: https://deps.rs/crate/iso17442-types/0.3.2/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/iso17442-types/0.3.2


### PR DESCRIPTION



## 🤖 New release

* `iso17442-types`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/jcape/iso17442/compare/v0.3.1...v0.3.2) - 2026-01-02

### Other

- make tests depend on alloc, not std.
- fix badges
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).