### PR TITLE
chore: release v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jcape/iso17442"
 rust-version = "1.87.0"
-version = "0.3.2"
+version = "0.3.3"
 
 [profile.release]
 lto = true

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/jcape/iso17442/compare/v0.3.2...v0.3.3) - 2026-01-15
+
+### Other
+
+- use 1.87.0 for tests, add to readme
+- use flat-square badges
+
 ## [0.3.2](https://github.com/jcape/iso17442/compare/v0.3.1...v0.3.2) - 2026-01-02
 
 ### Other

--- a/types/README.md
+++ b/types/README.md
@@ -34,7 +34,7 @@ assert_eq!(l.as_str(), LEI_STR);
 Both of these types are fully usable in the `const` context, making them suitable for use within static data.
 
 [crate-image]: https://img.shields.io/crates/v/iso17442-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/iso17442-types/0.3.2
+[crate-link]: https://crates.io/crates/iso17442-types/0.3.3
 [docs-image]: https://img.shields.io/docsrs/iso17442-types?style=for-the-badge
-[docs-link]: https://docs.rs/crate/iso17442-types/0.3.2
-[msrv-image]: https://img.shields.io/crates/msrv/iso17442-types/0.3.2?style=for-the-badge
+[docs-link]: https://docs.rs/crate/iso17442-types/0.3.3
+[msrv-image]: https://img.shields.io/crates/msrv/iso17442-types/0.3.3?style=for-the-badge


### PR DESCRIPTION



## 🤖 New release

* `iso17442-types`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/jcape/iso17442/compare/v0.3.2...v0.3.3) - 2026-01-15

### Other

- use 1.87.0 for tests, add to readme
- use flat-square badges
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).